### PR TITLE
お気に入りボタンのAjax化 #26

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -2,14 +2,12 @@ class FavoritesController < ApplicationController
   before_action :require_login
 
   def create
-    recipe = Recipe.find(params[:recipe_id])
-    current_user.favorite(recipe)
-    redirect_back fallback_location: root_path
+    @recipe = Recipe.find(params[:recipe_id])
+    current_user.favorite(@recipe)
   end
 
   def destroy
-    recipe = current_user.favorites.find(params[:id]).recipe
-    current_user.unfavorite(recipe)
-    redirect_back fallback_location: root_path
+    @recipe = current_user.favorites.find(params[:id]).recipe
+    current_user.unfavorite(@recipe)
   end
 end

--- a/app/views/favorites/create.js.erb
+++ b/app/views/favorites/create.js.erb
@@ -1,0 +1,1 @@
+$("#js-favorite-button-for-recipe-<%= @recipe.id %>").replaceWith("<%= j(render('recipes/unfavorite', recipe: @recipe)) %>");

--- a/app/views/favorites/destroy.js.erb
+++ b/app/views/favorites/destroy.js.erb
@@ -1,0 +1,1 @@
+$("#js-favorite-button-for-recipe-<%= @recipe.id %>").replaceWith("<%= j(render('recipes/favorite', recipe: @recipe)) %>");

--- a/app/views/recipes/_favorite.html.erb
+++ b/app/views/recipes/_favorite.html.erb
@@ -1,3 +1,6 @@
-<%= link_to favorites_path(recipe_id: recipe.id), id: "js-favorite-button-for-recipe-#{recipe.id}", method: :post do %>
+<%= link_to favorites_path(recipe_id: recipe.id),
+            id: "js-favorite-button-for-recipe-#{recipe.id}",
+            method: :post,
+            remote: true do %>
   <%= icon 'far', 'star' %>
 <% end %>

--- a/app/views/recipes/_unfavorite.html.erb
+++ b/app/views/recipes/_unfavorite.html.erb
@@ -1,3 +1,6 @@
-<%= link_to favorite_path(current_user.favorites.find_by(recipe_id: recipe.id)), id: "js-favorite-button-for-recipe-#{recipe.id}", method: :delete do %>
+<%= link_to favorite_path(current_user.favorites.find_by(recipe_id: recipe.id)),
+            id: "js-favorite-button-for-recipe-#{recipe.id}",
+            method: :delete,
+            remote: true do %>
   <%= icon 'fas', 'star' %>
 <% end %>


### PR DESCRIPTION
## 概要

- お気に入りボタンのAjax化
- `link_to`に`remote: true`を追加
- `favorites_controller`を変更
- `/recipes/create.js.erb`と`/recipes/destroy.js.erb`を作成

## コメント

close #26 