### PR TITLE
ユーザー登録画面のデザイン修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,4 @@ gem 'rails_admin', ['>= 3.0.0.beta2', '< 4']
 gem 'dotenv-rails'
 gem 'bootstrap', '~> 4.3.1'
 gem 'jquery-rails'
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,6 +226,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
+    rails-i18n (7.0.1)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     rails_admin (3.0.0.beta2)
       activemodel-serializers-xml (>= 1.0)
       kaminari (>= 0.14, < 2.0)
@@ -354,6 +357,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 6.1.4)
+  rails-i18n
   rails_admin (>= 3.0.0.beta2, < 4)
   ransack
   rspec-rails

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 
-  <body style="padding-top: 71px" class="text-center">
+  <body style="padding-top: 71px">
     <% if request.path == '/' %>
       <%= render 'layouts/root_header' %>
     <% else %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -4,11 +4,11 @@
       <h3>ログイン</h3>
       <%= form_with url: login_path, local: true do |f| %>
         <div class="form-group">
-          <%= f.label :email %>
+          <%= f.label :email, User.human_attribute_name(:email) %>
           <%= f.text_field :email, class: 'form-control' %>
         </div>
         <div class="form-group">
-          <%= f.label :password %>
+          <%= f.label :password, User.human_attribute_name(:password) %>
           <%= f.password_field :password, class: 'form-control' %>
         </div>
         <div class="actions">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <div class="row">
-    <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+    <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
       <h3>ログイン</h3>
       <%= form_with url: login_path, local: true do |f| %>
         <div class="form-group">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,13 +1,28 @@
 <div class="container">
-  <%= form_with model: @user, local: true do |f| %>
-    <%= f.label :name %>
-    <%= f.text_field :name %>
-    <%= f.label :email %>
-    <%= f.text_field :email %>
-    <%= f.label :password %>
-    <%= f.password_field :password %>
-    <%= f.label :password_confirmation %>
-    <%= f.password_field :password_confirmation %>
-    <%= f.submit "登録" %>
-  <% end %>
+  <div class="row">
+    <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+      <h3>新規ユーザー登録</h3>
+      <%= form_with model: @user, local: true do |f| %>
+        <div class="form-group">
+          <%= f.label :name %>
+          <%= f.text_field :name, class: 'form-control' %>
+        </div>
+        <div class="form-group">
+          <%= f.label :email %>
+          <%= f.text_field :email, class: 'form-control' %>
+        </div>
+        <div class="form-group">
+          <%= f.label :password %>
+          <%= f.password_field :password, class: 'form-control' %>
+        </div>
+        <div class="form-group">
+          <%= f.label :password_confirmation %>
+          <%= f.password_field :password_confirmation, class: 'form-control' %>
+        </div>
+        <div class="actions">
+          <%= f.submit "登録", class: "btn btn-secondary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,5 +34,8 @@ module SpiceCurryMania
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}').to_s]
   end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,11 @@
+ja:
+  activerecord:
+    model:
+      user: 'ユーザー'
+      recipe: 'レシピ'
+    attributes:
+      user:
+        name: 'ユーザー名'
+        email: 'メールアドレス'
+        password: 'パスワード'
+        password_confirmation: 'パスワード確認'


### PR DESCRIPTION
## 概要

- `bootstrap`を使用してログインフォームと同じようにデザインを修正
- gem`rails-i18n`を追加し、フォームに日本語でラベルが表示されるようにした。

## 確認方法

1. Gem を追加したので `bundle install` を実行してください

## コメント

レシピ投稿ページのデザインを修正する際にまた適宜`ja.yml`に追加していく。
close #42