### PR TITLE
レシピ詳細ページのデザイン修正 #48

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,3 +29,6 @@
    color: #3f3f3f;
  }
 
+ .container-m {
+   margin-top: 20px;
+ }

--- a/app/views/recipes/_crud_menus.html.erb
+++ b/app/views/recipes/_crud_menus.html.erb
@@ -1,2 +1,2 @@
-<%= link_to '編集', edit_recipe_path(recipe) %>
-<%= link_to '削除', recipe_path(recipe), method: :delete %>
+<%= link_to 'このレシピを編集する', edit_recipe_path(recipe) %><br>
+<%= link_to 'このレシピを削除する', recipe_path(recipe), method: :delete %>

--- a/app/views/recipes/_favorite_button.html.erb
+++ b/app/views/recipes/_favorite_button.html.erb
@@ -1,5 +1,11 @@
+<p><%= icon 'far', 'user' %>
+  <%= recipe.user.name %>さんのレシピ
+  <%= link_to user_path(recipe.user), class: 'text-decoration-none link' do %>
+    <br><%= recipe.user.name %>さんの他のレシピを見る
+  <% end %>
+</p>
 <% if current_user.favorite?(recipe) %>
-  <%= render 'unfavorite', { recipe: recipe } %>
+  お気に入り <%= render 'unfavorite', { recipe: recipe } %>
 <% else %>
-  <%= render 'favorite', { recipe: recipe } %>
+  お気に入り <%= render 'favorite', { recipe: recipe } %>
 <% end %>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -1,31 +1,36 @@
 <div class="container">
-  <div class="racipe_top">
-    <%= image_tag @recipe.image.url, size: '350x350' %>
-    <%= @recipe.name %>
-    <% if current_user.own?(@recipe) %>
-      <%= render 'crud_menus', recipe: @recipe %>
-    <% else %>
-      <%= render 'favorite_button', recipe: @recipe %>
-    <% end %>
-    <p>カレーの種類: <%= @recipe.category %></p>
-  </div>
-  <div class="ingredients">
-  <p>材料<%= @recipe.survings %>人前</p>
-    <% @recipe.ingredients.pluck('name', 'quantity').each do |ingredient, quantity| %>
-      <%= ingredient %><%= quantity %>
-    <% end %>
-  </div>
-  <div class="spices">
-  <p>スパイス</p>
+  <div class="row">
+    <div class="col-md-6">
+      <h2><%= @recipe.name %></h2>
+      <%= image_tag @recipe.image.url, class: 'img-fluid' %>
+      <br>
+      <% if current_user.own?(@recipe) %>
+        <%= render 'crud_menus', recipe: @recipe %>
+      <% else %>
+        <%= render 'favorite_button', recipe: @recipe %>
+      <% end %>
+    </div>
+    <div class="col-md-3">
+      <h3>材料<%= @recipe.survings %>人分</h3>
+      <% @recipe.ingredients.pluck('name', 'quantity').each do |ingredient, quantity| %>
+        •<%= ingredient %>  <%= quantity %><br>
+      <% end %>
+    </div>
+    <div class="col-md-3">
+    <h3>使用するスパイス</h3>
     <% @recipe.spices.pluck('name', 'quantity').each do |spice, quantity| %>
-      <%= spice %><%= quantity %>
+      •<%= spice %>  <%= quantity %><br>
     <% end %>
   </div>
-  <div class="steps">
-  <p>作り方</p>
-    <% @recipe.steps.pluck('direction').each do |direction| %>
-      <%= direction %>
+</div>
+<div class="container container-m">
+  <h3>作り方</h3>
+    <% @recipe.steps.each do |step| %>
+      •<%= step.direction %>
+      <% if step.image? %>
+        <br>
+        <%= image_tag step.image.url, class: "col-md-4" %>
+      <% end %>
       <br>
     <% end %>
-  </div>
 </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -12,7 +12,7 @@ ja:
         password_confirmation: 'パスワード確認'
       recipe:
         name: 'レシピ名'
-        survings: '何人前'
+        survings: '何人分'
         category: '種類'
         image: 'レシピ画像'
       step:


### PR DESCRIPTION
## 概要

- `bootstrap`を利用して、レシピ詳細ページのデザインを修正
- 材料、スパイス、作り方を見やすく表示されるようにした。
- 作り方の手順に、画像がある場合表示されるようにした。
- レシピ詳細ページからでも、そのレシピの投稿者のページに飛べるようにリンクを設置した。

## コメント

close #48 