### PR TITLE
レシピ名が改行されるように修正 #52

### DIFF
--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
     <div class="col-md-6">
-      <h2><%= @recipe.name %></h2>
+      <h2 class="text-break"><%= @recipe.name %></h2>
       <%= image_tag @recipe.image.url, class: 'img-fluid' %>
       <br>
       <% if current_user.own?(@recipe) %>


### PR DESCRIPTION
## 概要

レシピ名が長すぎると、改行されずにレシピページの材料とかぶってしまう問題点を、レシピ名に`text-break`クラスをつけることで解決した。


## コメント

close #52 