### PR TITLE
お問い合わせにGoogleフォームを設置 #56

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -15,7 +15,7 @@
       <!--Grid column-->
       <div class="col-lg-6 col-md-12 mb-4 mb-md-0">
         <ul>
-          <li>お問い合わせ</li>
+          <li><%= link_to 'お問い合わせ', 'https://docs.google.com/forms/d/e/1FAIpQLScjVgvrFCBfNE4esHqLOzk1h_r-mUUGeOkfoN5CzvBH6YKVNQ/viewform?usp=sf_link', class: "link" %></li>
           <li><%= link_to '利用規約', page_path('terms'), class: "link" %></li>
           <li><%= link_to 'プライバシーポリシー', page_path('privacy'), class: "link" %></li>
         </ul>


### PR DESCRIPTION
## 概要

フッターのお問い合わせをクリックすると、Googleフォームが開くようにリンクを設置。
ユーザーが入力すると、自動で返信されるように設定した。

## コメント

close #56 