### PR TITLE
他ユーザーのプロフィール編集ページとレシピ編集ページにアクセスできないようにする

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -1,5 +1,6 @@
 class RecipesController < ApplicationController
   before_action :require_login
+  before_action :set_recipe, only: %i[show edit update destroy]
   skip_before_action :require_login, only: [:index, :show]
 
   def index
@@ -24,12 +25,9 @@ class RecipesController < ApplicationController
     end
   end
 
-  def edit
-    @recipe = Recipe.find_by(id: params[:id])
-  end
+  def edit; end
 
   def update
-    @recipe = Recipe.find_by(id: params[:id])
     if @recipe.update(recipe_params)
       redirect_to root_path
       flash[:warning] = t('.success')
@@ -39,17 +37,18 @@ class RecipesController < ApplicationController
     end
   end
 
-  def show
-    @recipe = Recipe.find_by(id: params[:id])
-  end
+  def show; end
 
   def destroy
-    @recipe = Recipe.find_by(id: params[:id])
     @recipe.destroy
     redirect_to root_path, warning: t('.success')
   end
 
   private
+
+  def set_recipe
+    @recipe = Recipe.find_by(id: params[:id])
+  end
 
   def recipe_params
     params.require(:recipe).permit(:name, :survings, :category, :image, ingredients_attributes: [:id, :name, :quantity, :_destroy], spices_attributes: [:id, :name, :quantity, :classification, :_destory], steps_attributes: [:id, :direction, :image, :_destroy])

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -1,6 +1,7 @@
 class RecipesController < ApplicationController
   before_action :require_login
   before_action :set_recipe, only: %i[show edit update destroy]
+  before_action :verify_access, only: %i[edit udpate destroy]
   skip_before_action :require_login, only: [:index, :show]
 
   def index
@@ -52,5 +53,9 @@ class RecipesController < ApplicationController
 
   def recipe_params
     params.require(:recipe).permit(:name, :survings, :category, :image, ingredients_attributes: [:id, :name, :quantity, :_destroy], spices_attributes: [:id, :name, :quantity, :classification, :_destory], steps_attributes: [:id, :direction, :image, :_destroy])
+  end
+
+  def verify_access
+    redirect_to root_path, danger: "そのページにはアクセスできません" unless current_user.id == @recipe.user_id
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -50,6 +50,6 @@ class UsersController < ApplicationController
   end
 
   def verify_access
-    redirect_to root_path, danger: "そのページにはログインできません" unless @current_user == @user
+    redirect_to root_path, danger: "そのページにはアクセスできません" unless @current_user == @user
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
   before_action :require_login
   before_action :set_user, only: %i[edit update show]
+  before_action :verify_access, only: %i[edit update]
   skip_before_action :require_login, only: [:new, :create, :show]
 
   def new
@@ -46,5 +47,9 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:name, :email, :password, :password_confirmation, :image)
+  end
+
+  def verify_access
+    redirect_to root_path, danger: "そのページにはログインできません" unless @current_user == @user
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :require_login
+  before_action :set_user, only: %i[edit update show]
   skip_before_action :require_login, only: [:new, :create, :show]
 
   def new
@@ -17,12 +18,9 @@ class UsersController < ApplicationController
     end
   end
 
-  def edit 
-    @user = User.find_by(id: params[:id])
-  end
+  def edit; end
 
   def update
-    @user = User.find_by(id: params[:id])
     if @user.update(user_params)
       redirect_to root_path
       flash[:warning] = t('.success')
@@ -33,7 +31,6 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find_by(id: params[:id])
     @recipes = @user.recipes.order('updated_at DESC').page(params[:page])
   end
 
@@ -42,6 +39,10 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def set_user
+    @user = User.find_by(id: params[:id])
+  end
 
   def user_params
     params.require(:user).permit(:name, :email, :password, :password_confirmation, :image)

--- a/spec/system/recipes_spec.rb
+++ b/spec/system/recipes_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "Recipes", type: :system do
     end
 
     describe 'レシピ編集' do
-      let!(:recipe) { create(:recipe_with_all) }
+      let!(:recipe) { create(:recipe_with_all, user: user) }
       before { visit edit_recipe_path(recipe) }
 
       context 'フォームの入力値が正常' do

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "Users", type: :system do
         it '編集ページへのアクセスが失敗する' do
           visit edit_user_path(other_user)
           expect(page).to have_content "そのページにはアクセスできません"
-          expect(currnet_path).to eq root_path
+          expect(current_path).to eq root_path
         end
       end
     end


### PR DESCRIPTION
## 概要

system specを作成した際に発覚した問題を解決する。
`verify_access`メソッドを追加して他ユーザーのプロフィール編集ページやレシピ編集ページにアクセスできないようにする。
もしurlを打ち込んでも、`そのページにはアクセスできません`と表示させる。

[![Image from Gyazo](https://i.gyazo.com/c0e56bdb1b6afb71fea40b95e2625e74.png)](https://gyazo.com/c0e56bdb1b6afb71fea40b95e2625e74)
テスト結果。これでエラーがなくなった。