### PR TITLE
スマホやタブレットで表示した時にフッターが被らないように編集 #85

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -76,3 +76,9 @@ footer {
    padding-left: 1rem;
    text-indent: -1rem;
  }
+
+ @media screen and (max-width: 991px) {
+   .main {
+     padding-bottom: 380px;
+   }
+ }


### PR DESCRIPTION
## 概要

スマホやタブレットで表示するとフッターが重なっていたので、cssを編集した。

## コメント

close #85